### PR TITLE
fix: failed tests due to a bad searching criterion

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -301,7 +301,7 @@ var newConnection = func(
 		// different from protocol.DefaultActiveConnectionIDLimit.
 		// If set to the default value, it will be omitted from the transport parameters, which will make
 		// old quic-go versions interpret it as 0, instead of the default value of 2.
-		// See https://github.com/refraction-networking/uquic/pull/3806.
+		// See https://github.com/quic-go/quic-go/pull/3806.
 		ActiveConnectionIDLimit:   protocol.MaxActiveConnectionIDs,
 		InitialSourceConnectionID: srcConnID,
 		RetrySourceConnectionID:   retrySrcConnID,
@@ -411,7 +411,7 @@ var newClientConnection = func(
 		// different from protocol.DefaultActiveConnectionIDLimit.
 		// If set to the default value, it will be omitted from the transport parameters, which will make
 		// old quic-go versions interpret it as 0, instead of the default value of 2.
-		// See https://github.com/refraction-networking/uquic/pull/3806.
+		// See https://github.com/quic-go/quic-go/pull/3806.
 		ActiveConnectionIDLimit:   protocol.MaxActiveConnectionIDs,
 		InitialSourceConnectionID: srcConnID,
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -35,7 +35,7 @@ import (
 func areConnsRunning() bool {
 	var b bytes.Buffer
 	pprof.Lookup("goroutine").WriteTo(&b, 1)
-	return strings.Contains(b.String(), "quic-go.(*connection).run")
+	return strings.Contains(b.String(), "uquic.(*connection).run")
 }
 
 var _ = Describe("Connection", func() {


### PR DESCRIPTION
... and fix two bad reference link to quic-go's repo: they were not meant to be found with uquic.