### PR TITLE
fix: link to quic-go in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Ginkgo Test Status](https://github.com/refraction-networking/uquic/actions/workflows/ginkgo_test.yml/badge.svg?branch=master)](https://github.com/refraction-networking/uquic/actions/workflows/ginkgo_test.yml)
 [![godoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/refraction-networking/uquic)
 ---
-uQUIC is a fork of [quic-go](https://github.com/refraction-networking/uquic), which provides Initial Packet fingerprinting resistance and other features. While the handshake is still performed by quic-go, this library provides interface to customize the unencrypted Initial Packet which may reveal fingerprint-able information. 
+uQUIC is a fork of [quic-go](https://github.com/quic-go/quic-go), which provides Initial Packet fingerprinting resistance and other features. While the handshake is still performed by quic-go, this library provides interface to customize the unencrypted Initial Packet which may reveal fingerprint-able information. 
 
 Golang 1.20+ is required.
 
@@ -32,7 +32,7 @@ If you are interested in our research, please stay tuned for our paper.
 		- [ ] QUIC ACK Frame (on hold)
 	- [x] TLS ClientHello Message (by [uTLS](https://github.com/refraction-networking/utls))
 		- [x] QUIC Transport Parameters (in a uTLS extension)
-- [ ] Customize Initial ACK behavior ([#1](https://github.com/refraction-networking/uquic/issues/1), [quic-go#4007](https://github.com/refraction-networking/uquic/issues/4007))
+- [ ] Customize Initial ACK behavior ([#1](https://github.com/refraction-networking/uquic/issues/1), [quic-go#4007](https://github.com/quic-go/quic-go/issues/4007))
 - [ ] Customize Initial Retry behavior ([#2](https://github.com/refraction-networking/uquic/issues/2))
 - [ ] Add preset QUIC parrots
 	- [x] Google Chrome parrot (call for parrots w/ `Token/PSK`)


### PR DESCRIPTION
Fix unintended changes that break links to the upstream.