### PR TITLE
Fix uquic panic in frames

### DIFF
--- a/u_quic_frames.go
+++ b/u_quic_frames.go
@@ -46,6 +46,12 @@ func (qfs QUICFrames) Build(cryptoData []byte) (payload []byte, err error) {
 				// calculate length: from offset to the end of cryptoData
 				length = len(cryptoData) - lengthOffset
 			}
+			// Guard against empty or insufficient cryptoData (e.g. probe packets
+			// that retransmit with no actual crypto payload).
+			if length <= 0 || lengthOffset >= len(cryptoData) {
+				length = 0
+				lengthOffset = 0
+			}
 			frameBytes = []byte{0x06} // CRYPTO frame type
 			frameBytes = quicvarint.Append(frameBytes, uint64(offset))
 			frameBytes = quicvarint.Append(frameBytes, uint64(length))
@@ -219,7 +225,16 @@ func (qrf *QUICRandomFrames) Build(cryptoData []byte) (payload []byte, err error
 	var frameList QUICFrames = make([]QUICFrame, 0)
 
 	var cryptoSafeRandUint64 = func(min, max uint64) (uint64, error) {
-		minMaxDiff := big.NewInt(int64(max - min))
+		if min >= max {
+			return min, nil
+		}
+		diff := max - min
+		// Guard against uint64 underflow at call sites: if the difference
+		// exceeds int64 range, the max was computed via underflowing subtraction.
+		if diff > uint64(math.MaxInt64) {
+			return min, nil
+		}
+		minMaxDiff := big.NewInt(int64(diff))
 		offset, err := rand.Int(rand.Reader, minMaxDiff)
 		if err != nil {
 			return 0, err

--- a/u_quic_frames_test.go
+++ b/u_quic_frames_test.go
@@ -171,3 +171,77 @@ var (
 		Length:     512,
 	}
 )
+
+// Verifies that Build does not panic when called with empty cryptoData.
+// This reproduces a scenario where a QUIC probe packet retransmits with
+// no actual crypto payload, causing uint64 underflow in the CRYPTO
+// frame length calculation.
+func TestQUICRandomFramesEmptyCryptoData(t *testing.T) {
+	qrf := &QUICRandomFrames{
+		MinPING:    0,
+		MaxPING:    3,
+		MinCRYPTO:  2, // Must be >=2 to enter the splitting loop
+		MaxCRYPTO:  4,
+		MinPADDING: 1,
+		MaxPADDING: 3,
+		Length:     100,
+	}
+
+	payload, err := qrf.Build([]byte{})
+	if err != nil {
+		t.Fatalf("Build with empty cryptoData returned error: %v", err)
+	}
+	if payload == nil {
+		t.Fatal("Build with empty cryptoData returned nil payload")
+	}
+}
+
+// Verifies Build handles the edge case where cryptoData is too small
+// to split across multiple CRYPTO frames without underflow.
+func TestQUICRandomFramesSingleByteCryptoData(t *testing.T) {
+	qrf := &QUICRandomFrames{
+		MinPING:    0,
+		MaxPING:    2,
+		MinCRYPTO:  3, // Requesting 3+ splits of 1 byte
+		MaxCRYPTO:  5,
+		MinPADDING: 1,
+		MaxPADDING: 2,
+		Length:     50,
+	}
+
+	payload, err := qrf.Build([]byte{0x42})
+	if err != nil {
+		t.Fatalf("Build with single-byte cryptoData returned error: %v", err)
+	}
+	if payload == nil {
+		t.Fatal("Build with single-byte cryptoData returned nil payload")
+	}
+}
+
+func TestQUICFramesEmptyCryptoData(t *testing.T) {
+	frames := QUICFrames{
+		QUICFrameCrypto{Offset: 0, Length: 0},
+	}
+
+	payload, err := frames.Build([]byte{})
+	if err != nil {
+		t.Fatalf("Build with empty cryptoData returned error: %v", err)
+	}
+	if payload == nil {
+		t.Fatal("Build returned nil payload")
+	}
+}
+
+func TestQUICFramesOffsetExceedsCryptoData(t *testing.T) {
+	frames := QUICFrames{
+		QUICFrameCrypto{Offset: 100, Length: 0}, // offset far beyond data
+	}
+
+	payload, err := frames.Build([]byte{0x01, 0x02, 0x03})
+	if err != nil {
+		t.Fatalf("Build with excessive offset returned error: %v", err)
+	}
+	if payload == nil {
+		t.Fatal("Build returned nil payload")
+	}
+}


### PR DESCRIPTION
Summary:
Fix a panic in QUICRandomFrames.Build when called with empty or insufficient crypto data (e.g. QUIC probe packets). The expression lenCryptoData-(numCRYPTO-i-2) underflows as uint64 when lenCryptoData is 0, producing a huge value that becomes negative when cast to int64 via big.NewInt, causing crypto/rand.Int to panic. The fix adds two guards: (1) in cryptoSafeRandUint64, detect uint64 underflow by checking diff > MaxInt64 and return min instead of panicking; (2) in QUICFrames.Build, handle the resulting zero-length or out-of-bounds crypto frames instead of indexing past the data.

Test Plan:
```
go test -v .

// Without the fix, tests repro the panic

panic: crypto/rand: argument to Int is <= 0 [recovered, repanicked]

goroutine 7444 [running]:
testing.tRunner.func1.2({0x104d5a860, 0x104e9e060})
	/opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:1974 +0x1a0
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:1977 +0x318
panic({0x104d5a860?, 0x104e9e060?})
	/opt/homebrew/Cellar/go/1.26.0/libexec/src/runtime/panic.go:860 +0x12c
crypto/rand.Int({0x104ea1de0?, 0x104fabda0?}, 0x329515c32e98?)
	/opt/homebrew/Cellar/go/1.26.0/libexec/src/crypto/rand/util.go:73 +0x25c
github.com/refraction-networking/uquic.(*QUICRandomFrames).Build.func1(...)
	/Users/utkugrkn/Desktop/Dev/uquic/u_quic_frames.go:223
github.com/refraction-networking/uquic.(*QUICRandomFrames).Build(0x329515c32f38, {0x329515c32f38, 0x0, 0x0})
	/Users/utkugrkn/Desktop/Dev/uquic/u_quic_frames.go:253 +0x4d0
github.com/refraction-networking/uquic.TestQUICRandomFramesEmptyCryptoData(0x329516033d48)
	/Users/utkugrkn/Desktop/Dev/uquic/u_quic_frames_test.go:194 +0x50
testing.tRunner(0x329516033d48, 0x104e99ba8)
	/opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2036 +0xc4
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x3a8
FAIL	github.com/refraction-networking/uquic	7.028s

```